### PR TITLE
Faster parsing heuristics for large files

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,14 @@ have the following commands available (with default keybindings).
 
 *The default bindings are subject to change as this package is in beta*
 
+# Configuration
+
+Yaml.el, being an Emacs lisp parser, struggles with very large files.
+You can configure the parser to parse a smaller section of the buffer
+via a heuristic (probably error prone).  Set the custom variable
+`yaml-pro-max-parse-size` to be the size of the buffer after which
+such a heuristic is used.
+
 # Recommendations
 
 - Yaml-pro's features compliments LSP and will enhance your YAML
@@ -78,6 +86,7 @@ have the following commands available (with default keybindings).
   - [x] block options for how to store the string.
   - [x] save default init command on a path basis
 - [x] Easy navigation (yaml-pro-jump)
+- [x] Partial tree-parsing for large files
 - [ ] Async parsing: preemptively parse document for faster editing
       (perhaps via idle timer).
 - [ ] Tools to work with various template modes.  Go-templated YAML is

--- a/yaml-pro-edit.el
+++ b/yaml-pro-edit.el
@@ -2,7 +2,7 @@
 
 ;; Author: Zachary Romero
 ;; Maintainer: Zachary Romero
-;; Version: 0.1.0
+;; Version: 0.1.1
 ;; Homepage: https://github.com/zkry/yaml-pro
 ;; Keywords: tools
 

--- a/yaml-pro-edit.el
+++ b/yaml-pro-edit.el
@@ -308,7 +308,7 @@ resulting in the function being ran upon subsequent edits."
 (declare-function yaml-pro--value-at-point "yaml-pro")
 (declare-function yaml-pro--fast-value-at-point "yaml-pro")
 (declare-function yaml-pro--path-at-point "yaml-pro")
-(defvar yaml-pro-max-parse-size)
+(declare-function yaml-pro--use-fast-p "yaml-pro")
 
 ;;;###autoload
 (defun yaml-pro-edit-scalar (p)
@@ -316,7 +316,7 @@ resulting in the function being ran upon subsequent edits."
 If prefix argument P is provided, prompt user for initialization command."
   (interactive "p")
   (let* ((init-func)
-         (fast-p (> (buffer-size) yaml-pro-max-parse-size))
+         (fast-p (yaml-pro--use-fast-p))
          (at-scalar (if fast-p (yaml-pro--fast-value-at-point)
                       (yaml-pro--value-at-point)))
          (path (and (not fast-p) (yaml-pro--path-at-point)))

--- a/yaml-pro.el
+++ b/yaml-pro.el
@@ -2,7 +2,7 @@
 
 ;; Author: Zachary Romero
 ;; Maintainer: Zachary Romero
-;; Version: 0.1.0
+;; Version: 0.1.1
 ;; Package-Requires: ((emacs "26.1") (yaml "0.5.1"))
 ;; Homepage: https://github.com/zkry/yaml-pro
 ;; Keywords: tools


### PR DESCRIPTION
This PR makes yaml-pro usable for very large files by using a heuristic to select a portion of the buffer to parse and use that tree for the various operations.