### PR TITLE
Switch from calling switch-to-buffer-other-window to display-buffer

### DIFF
--- a/yaml-pro-edit.el
+++ b/yaml-pro-edit.el
@@ -375,7 +375,9 @@ dedicated buffer")))))
           ;; otherwise use its scalar value (to not show quotes)
           (yaml-pro-edit-initialize-buffer
            parent-buffer b at-scalar type init-func path))
-        (switch-to-buffer-other-window b)))))
+        (let ((window (display-buffer b)))
+          (when window
+            (select-window window)))))))
 
 (provide 'yaml-pro-edit)
 


### PR DESCRIPTION
This PR makes sure that the edit buffer that's being created plays nice with Emacs window management system.