### PR TITLE
implement imenu for legacy parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ tree-sitter and non-tree-sitter variants.
 
 ![eldoc](./docs/eldoc.gif)
 
-### Imenu (tree-sitter)
+### Imenu
 
 ![imenu](./docs/imenu.gif)
 
@@ -67,7 +67,7 @@ buffer and convert between the various styles with ease.
 
 ![jumping feature](./docs/yaml-pro-jump.gif)
 
-If using tree-sitter variant, you should be able to just use imenu.
+You can use imenu as well.
 
 ### Moving subtrees up and down
 
@@ -155,8 +155,9 @@ have the following commands available (with default keybindings).
 - **yaml-pro-edit-scalar** (<kbd>C-c '</kbd>)
   - (use prefix argument <kbd>C-u</kbd> to supply an initialization
     command to set major mode)
-- **yaml-pro-jump** (or **yaml-pro-consult-jump** if using consult)
-  (<kbd>C-c C-j</kbd>)
+- If your buffer is in yaml-pro-mode, `imenu` should index the entire
+  buffer's paths.
+
 
 *The default bindings are subject to change as this package is in beta*
 

--- a/yaml-pro.el
+++ b/yaml-pro.el
@@ -2,7 +2,7 @@
 
 ;; Author: Zachary Romero
 ;; Maintainer: Zachary Romero
-;; Version: 0.1.4
+;; Version: 0.3.1
 ;; Package-Requires: ((emacs "26.1") (yaml "0.5.1"))
 ;; Homepage: https://github.com/zkry/yaml-pro
 ;; Keywords: tools
@@ -1038,7 +1038,7 @@ Indentation is controlled by the variable `yaml-pro-indent'."
       (save-excursion
         (forward-line 0)
         (unless (looking-at-p (make-string yaml-pro-indent ?\s))
-          (error "subtree can't be unintented further.")))
+          (error "Subtree can't be unintented further")))
       (if (not (looking-back "^[ ]*" nil))
           (progn
             (forward-line 0)
@@ -1085,6 +1085,7 @@ Indentation is controlled by the variable `yaml-pro-indent'."
   (yaml-pro-next-subtree))
 
 (defun yaml-pro-create-index ()
+  "Create an imenu index using the legacy parser."
   (let* ((tree (yaml-parse-string-with-pos (buffer-string)))
          (paths (yaml-pro--extract-paths tree))
          (sorted-paths (seq-sort-by (lambda (path)
@@ -1121,6 +1122,8 @@ Indentation is controlled by the variable `yaml-pro-indent'."
       (define-key map (kbd "C-c C-j") (if (featurep 'consult)
                                           #'yaml-pro-consult-jump
                                         #'yaml-pro-jump)))))
+
+(make-obsolete 'yaml-pro-consult-jump "Use imenu feature instead of this command." "0.3.2")
 
 (defconst yaml-pro-required-yaml-parser-version "0.5.1")
 


### PR DESCRIPTION
Fixes #18 

This PR adds imenu functionality for the legacy parser. This should entirely replace the `yaml-pro-consult-jump` function as `consult-imenu` should behave the same way with `yaml-pro-mode` enabled.