### PR TITLE
Move point back to indentation before indenting

### DIFF
--- a/yaml-pro.el
+++ b/yaml-pro.el
@@ -1059,9 +1059,10 @@ PATH is the current path we have already traversed down."
 
 Indentation is controlled by the variable `yaml-pro-indent'."
   (interactive)
-  (let* ((parse-tree (yaml-pro--get-buffer-tree))
-         (at-bounds (yaml-pro-get-block-bounds parse-tree (point))))
-    (save-excursion
+  (save-excursion
+    (back-to-indentation)
+    (let* ((parse-tree (yaml-pro--get-buffer-tree))
+           (at-bounds (yaml-pro-get-block-bounds parse-tree (point))))
       (goto-char (car at-bounds))
       (if (not (looking-back "^[ ]*" nil))
           (progn


### PR DESCRIPTION
This MR fixes some weird behavior of the non-ts indent function by moving the point before indenting.

Fixes #26 