### PR TITLE
Suggest enabling yaml-pro-mode last

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ required version with the variable
 `yaml-pro-required-yaml-parser-version`.
 
 You can have yaml-pro-mode setup on yaml-mode loading with the
-configuration: `(add-hook 'yaml-mode-hook #'yaml-pro-mode)`
+configuration: `(add-hook 'yaml-mode-hook #'yaml-pro-mode 100)`
 
 ## Usage
 


### PR DESCRIPTION
Otherwise `yaml-set-imenu-generic-expression` (default in yaml-mode-hook) will be executed after `yaml-pro-mode` sets imenu up, overwriting the configuration created by this package.