### PR TITLE
Copy element path to clipboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ re-implementation supports everything below, as well as the following:
   subtree, fixing indentation to be correct for different levels.
   When `yaml-pro-ts-yank-subtrees` is non-nil, yank will automatically
   call `yaml-pro-ts-paste-subtree` for subtrees.
+- **yaml-pro-copy-node-path-at-point**: Copy element path at point to
+  clipboard
 - **imenu**: an index of all keys and their path are build for imenu
 - **eldoc**: current path is shown as eldoc documentation. (enable
   with `eldoc-mode`)

--- a/yaml-pro.el
+++ b/yaml-pro.el
@@ -102,6 +102,14 @@
       (kill-region (treesit-node-start tree-top)
                    (treesit-node-end tree-top)))))
 
+(defun yaml-pro-copy-node-path-at-point ()
+  "Copy node path at point to clipboard."
+  (interactive)
+  (let* ((at-node (treesit-node-at (point) 'yaml))
+         (path (yaml-pro-ts--imenu-node-label at-node)))
+    (kill-new path)
+    (message "%s was copied to clipboard" (propertize path 'face '(bold default)))))
+
 (defun yaml-pro-ts-up-level ()
   "Move the point to the parent tree."
   (interactive)


### PR DESCRIPTION
Use the current node at point, extract its full path and copy it to
clipboard using `kill-new`