### PR TITLE
make treesit import not error if not exist

### DIFF
--- a/yaml-pro-format.el
+++ b/yaml-pro-format.el
@@ -35,7 +35,7 @@
 
 ;;; Code:
 
-(require 'treesit)
+(require 'treesit nil t)
 (require 'cl-lib)
 
 (defvar yaml-pro-indent)


### PR DESCRIPTION
This MR fixes a treesit import to not error if it doesn't exist. This is what the other files do, I missed this one.

Resolves #57 