### PR TITLE
Add yaml-pro-ts-mode to generated autoloads

### DIFF
--- a/yaml-pro.el
+++ b/yaml-pro.el
@@ -700,6 +700,7 @@ KEYS are added as increasingly nested levels."
       (define-key map (kbd "C-c '") #'yaml-pro-edit-ts-scalar)))
   "Map for minor mode `yaml-pro-ts-mode'.")
 
+;;;###autoload
 (define-minor-mode yaml-pro-ts-mode
   "Minor mode to enable yaml-pro treesitter keymap.
 


### PR DESCRIPTION
So the symbol is bound when doing for instance:

(add-hook 'yaml-mode-hook 'yaml-pro-ts-mode 100)