### PR TITLE
Allow compact maps and sequences for yaml-pro-ts-yank

### DIFF
--- a/yaml-pro.el
+++ b/yaml-pro.el
@@ -441,19 +441,17 @@ hierarchy of headlines by UP levels before marking the subtree."
 (defun yaml-pro-ts--kill-is-subtree (&optional tree)
   "Return non-nil if TREE (or current kill) is a valid tree."
   (unless tree
-    (setq tree (current-kill 0)))
-  (let* ((kill (and kill-ring (current-kill 0))))
-    (when (and kill (> (length (string-split kill "\n")) 1))
-      (let ((node (treesit-parse-string kill 'yaml)))
-        (treesit-query-capture node '((block_mapping_pair) @key))))))
+    (setq tree (and kill-ring (current-kill 0))))
+  (when (and tree (> (length (string-split tree "\n")) 1))
+    (let ((node (treesit-parse-string tree 'yaml)))
+      (treesit-query-capture node '((block_mapping_pair) @key)))))
 
 (defun yaml-pro-ts--kill-is-sequence (&optional tree)
   "Return non-nil if TREE (or current kill) is a valid sequence."
   (unless tree
-    (setq tree (current-kill 0)))
-  (let* ((kill (and kill-ring (current-kill 0)))
-         (first-line (car (string-split (string-trim-left kill) "\n"))))
-    (when (and kill (> (length (string-split kill "\n")) 1))
+    (setq tree (and kill-ring (current-kill 0))))
+  (let ((first-line (car (string-split (string-trim-left tree) "\n"))))
+    (when (and tree (> (length (string-split tree "\n")) 1))
       (let ((node (treesit-parse-string first-line 'yaml)))
         (treesit-query-capture node '((block_sequence) @key))))))
 


### PR DESCRIPTION
`yaml-pro-ts-yank` adjusts indents only if the line is blank.

This commit allows the line to have block struct indicators.

Examples:

Suppose the kill ring have the following fragment:

```yaml
bbb: 1
ccc: 2
```

and _ is the point, then:

```yaml
aaa: _

↓ yaml-pro-ts-yank

aaa: bbb: 1
     ccc: 2

```

```yaml
- _

↓ yaml-pro-ts-yank

- bbb: 1
  ccc: 2
```

```yaml
? _

↓ yaml-pro-ts-yank

? bbb: 1
  ccc: 2
```

```yaml
? aaa
: _

↓ yaml-pro-ts-yank

? aaa
: bbb: 1
  ccc: 2
```
