### PR TITLE
Add delete-section property to yaml-pro-ts-yank

### DIFF
--- a/yaml-pro.el
+++ b/yaml-pro.el
@@ -650,6 +650,8 @@ inserted to make the tree retain its original structure."
         (yaml-pro-ts-paste-subtree))
        (t (call-interactively #'yank))))))
 
+(put 'yaml-pro-ts-yank 'delete-selection t)
+
 (defun yaml-pro-ts-newline (&optional arg interactive)
   (interactive "*P\np")
   (barf-if-buffer-read-only)


### PR DESCRIPTION
Fixes #71 

In order for the yaml-pro-ts-yank command to behave like the yank command, the property `delete-section` needs to be set for `yaml-pro-ts-yank`.  This is the property that delete-selection-mode looks at.